### PR TITLE
Ensure data dir is created as parent to licenses dir.

### DIFF
--- a/samplesdb/licenses.py
+++ b/samplesdb/licenses.py
@@ -91,7 +91,7 @@ class LicensesFactory(object):
     def __init__(self, cache_dir):
         self._cache_dir = cache_dir
         if not os.path.exists(self._cache_dir):
-            os.mkdir(self._cache_dir)
+            os.makedirs(self._cache_dir)
 
     @property
     def _cache_file(self):


### PR DESCRIPTION
The `development.ini` file defines the following directory:

```
licenses_cache_dir = %(here)s/data/licenses
```

The `samplesdb.licenses.LicensesFactory` class fails when trying to create the `licenses` dir because the parent `data` dir doesn't exist yet. Change made to also create the `data` dir.
