### PR TITLE
Updated development server port to reflect README docs.

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -31,7 +31,7 @@ sample_attachments_dir = %(here)s/data/sample_attachments
 [server:main]
 use = egg:waitress#main
 host = 0.0.0.0
-port = 6543
+port = 8080
 
 # Begin logging configuration
 


### PR DESCRIPTION
The README says that the development server will be started on port 8080, however it's actually started on port 6543. Either the docs or the `development.ini` file need changing to bring these in line. Plumped for the `development.ini` on the basis that the port might as well be the same as the production port... :)
